### PR TITLE
Add fault injection capabilities to selected tests

### DIFF
--- a/carfield/dmr_matmul/Makefile
+++ b/carfield/dmr_matmul/Makefile
@@ -4,4 +4,9 @@ PULP_APP_SRCS = dmr_matmul.c
 PULP_CFLAGS = -O3
 PULP_LDFLAGS = -lm
 
+ifdef fault_inject
+	export FAULT_INJECTION=1
+	export FAULT_INJECTION_SCRIPT=pulp_inject_fault.tcl
+endif
+
 include $(PULP_SDK_HOME)/install/rules/pulp.mk

--- a/carfield/dmr_matmul/pulp_inject_fault.tcl
+++ b/carfield/dmr_matmul/pulp_inject_fault.tcl
@@ -1,0 +1,51 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Michael Rogenmoser (michaero@iis.ee.ethz.ch)
+
+transcript quietly
+if {! [info exists ::env(VSIM_PATH)]} {error "Define VSIM_PATH"}
+set utils_base_path  [file join $::env(VSIM_PATH) scripts fault_injection_utils]
+set script_base_path [file join $::env(VSIM_PATH) fault_injection_sim scripts]
+
+set verbosity            2
+set log_injections       1
+# Easy way to generate a variable seed
+# set seed                 [clock seconds]
+# Default value
+set seed                 12345
+set print_statistics     1
+
+set inject_start_time 250856000000ps
+set inject_stop_time 413000000000ps
+set injection_clock "pulp_cluster_tb/cluster_i/clk_i"
+set injection_clock_trigger 0
+set fault_period 250
+set rand_initial_injection_phase 0
+# max_num set to 0 means until stop_time
+set max_num_fault_inject 0
+set signal_fault_duration 20ns
+set register_fault_duration 0ns
+
+set allow_multi_bit_upset 1
+set use_bitwidth_as_weight 0
+set check_core_output_modification 0
+set check_core_next_state_modification 0
+set reg_to_sig_ratio 1
+
+source [file join $utils_base_path pulp_extract_nets.tcl]
+
+set inject_signals_netlist []
+set inject_register_netlist []
+set output_netlist []
+set next_state_netlist []
+set assertion_disable_list []
+
+for {set idx 0} {$idx < 12} {incr idx} {
+    set inject_signals_netlist [list {*}$inject_signals_netlist {*}[get_all_core_nets $idx]]
+    set output_netlist [list {*}$output_netlist {*}[get_core_output_nets $idx]]
+}
+
+source [file join $script_base_path inject_fault.tcl]
+

--- a/carfield/ecc_test/Makefile
+++ b/carfield/ecc_test/Makefile
@@ -3,4 +3,9 @@ PULP_APP_SRCS = ecc_test.c
 
 PULP_CFLAGS = -O3
 
+ifdef fault_inject
+	export FAULT_INJECTION=1
+	export FAULT_INJECTION_SCRIPT=pulp_inject_fault.tcl
+endif
+
 include $(PULP_SDK_HOME)/install/rules/pulp.mk

--- a/carfield/ecc_test/Makefile
+++ b/carfield/ecc_test/Makefile
@@ -5,7 +5,11 @@ PULP_CFLAGS = -O3
 
 ifdef fault_inject
 	export FAULT_INJECTION=1
-	export FAULT_INJECTION_SCRIPT=pulp_inject_fault.tcl
+	export FAULT_INJECTION_SCRIPT=$(CURDIR)/pulp_inject_fault.tcl
+endif
+
+ifdef multi_bit_upset
+	export MULTI_BIT_UPSET=1
 endif
 
 include $(PULP_SDK_HOME)/install/rules/pulp.mk

--- a/carfield/ecc_test/ecc_test.c
+++ b/carfield/ecc_test/ecc_test.c
@@ -65,5 +65,5 @@ int main() {
 
   printf("mismatch_cnt: %d, fix_cnt: %d, uncorrectable_cnt: %d\n", mismatch_cnt, fix_cnt, uncorrectable_cnt);
 
-  return (error != 0) || (uncorrectable_cnt != 0);
+  return (error != 0) ^ (uncorrectable_cnt != 0);
 }

--- a/carfield/ecc_test/ecc_test.c
+++ b/carfield/ecc_test/ecc_test.c
@@ -54,6 +54,16 @@ int main() {
     }
   }
 
-  return error;
+  unsigned int mismatch_cnt = 0;
+  unsigned int fix_cnt = 0;
+  unsigned int uncorrectable_cnt = 0;
+  for (int i = 0; i < 16; i++) {
+    mismatch_cnt += tcdm_scrubber_get_mismatch_count(cluster_id, i);
+    fix_cnt += tcdm_scrubber_get_fix_count(cluster_id, i);
+    uncorrectable_cnt += tcdm_scrubber_get_uncorrectable_count(cluster_id, i);
+  }
 
+  printf("mismatch_cnt: %d, fix_cnt: %d, uncorrectable_cnt: %d\n", mismatch_cnt, fix_cnt, uncorrectable_cnt);
+
+  return (error != 0) || (uncorrectable_cnt != 0);
 }

--- a/carfield/ecc_test/pulp_inject_fault.tcl
+++ b/carfield/ecc_test/pulp_inject_fault.tcl
@@ -6,7 +6,7 @@
 
 transcript quietly
 if {! [info exists ::env(VSIM_PATH)]} {error "Define VSIM_PATH"}
-set utils_base_path  [file join $::env(VSIM_PATH) scripts fault_injection_config]
+set utils_base_path  [file join $::env(VSIM_PATH) scripts fault_injection_utils]
 set script_base_path [file join $::env(VSIM_PATH) fault_injection_sim scripts]
 
 set verbosity            2
@@ -28,7 +28,7 @@ set max_num_fault_inject 0
 set signal_fault_duration 20ns
 set register_fault_duration 0ns
 
-set allow_multi_bit_upset 1
+set allow_multi_bit_upset [info exists ::env(MULTI_BIT_UPSET)]
 set use_bitwidth_as_weight 0
 set check_core_output_modification 0
 set check_core_next_state_modification 0

--- a/carfield/ecc_test/pulp_inject_fault.tcl
+++ b/carfield/ecc_test/pulp_inject_fault.tcl
@@ -1,0 +1,53 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Michael Rogenmoser (michaero@iis.ee.ethz.ch)
+
+transcript quietly
+if {! [info exists ::env(VSIM_PATH)]} {error "Define VSIM_PATH"}
+set utils_base_path  [file join $::env(VSIM_PATH) scripts fault_injection_config]
+set script_base_path [file join $::env(VSIM_PATH) fault_injection_sim scripts]
+
+set verbosity            2
+set log_injections       1
+# Easy way to generate a variable seed
+# set seed                 [clock seconds]
+# Default value
+set seed                 12345
+set print_statistics     1
+
+set inject_start_time 110584000000ps
+set inject_stop_time 203880000000ps
+set injection_clock "pulp_cluster_tb/cluster_i/clk_i"
+set injection_clock_trigger 0
+set fault_period 100
+set rand_initial_injection_phase 0
+# max_num set to 0 means until stop_time
+set max_num_fault_inject 0
+set signal_fault_duration 20ns
+set register_fault_duration 0ns
+
+set allow_multi_bit_upset 1
+set use_bitwidth_as_weight 0
+set check_core_output_modification 0
+set check_core_next_state_modification 0
+set reg_to_sig_ratio 1
+
+source [file join $utils_base_path pulp_extract_nets.tcl]
+
+set inject_signals_netlist []
+set inject_register_netlist []
+set output_netlist []
+set next_state_netlist []
+set assertion_disable_list []
+
+# for {set idx 0} {$idx < 12} {incr idx} {
+#     set inject_signals_netlist [list {*}$inject_signals_netlist {*}[get_all_core_nets $idx]]
+#     set output_netlist [list {*}$output_netlist {*}[get_core_output_nets $idx]]
+# }
+
+set inject_register_netlist [list {*}$inject_register_netlist {*}[get_memory_slice {0 16} {385 449}]]
+
+source [file join $script_base_path inject_fault.tcl]
+


### PR DESCRIPTION
Update `ecc_test` and `dmr_matmul` tests to allow also fault injection to stress test the HMR module and the ECC scrubbers.
Ideally, adding `fault_inject=1` to the `make clean all run` command runs the fault injection according to the `pulp_inject_fault.tcl` in the chosen test folder.