### PR TITLE
Add fault injection tests tailored for CI

### DIFF
--- a/carfield/dmr_matmul/Makefile
+++ b/carfield/dmr_matmul/Makefile
@@ -4,9 +4,9 @@ PULP_APP_SRCS = dmr_matmul.c
 PULP_CFLAGS = -O3
 PULP_LDFLAGS = -lm
 
-ifdef fault_inject
+ifeq ($(fault_inject),1)
 	export FAULT_INJECTION=1
-	export FAULT_INJECTION_SCRIPT=pulp_inject_fault.tcl
+	export FAULT_INJECTION_SCRIPT=$(CURDIR)/pulp_inject_fault.tcl
 endif
 
 include $(PULP_SDK_HOME)/install/rules/pulp.mk

--- a/carfield/ecc_test/Makefile
+++ b/carfield/ecc_test/Makefile
@@ -3,12 +3,12 @@ PULP_APP_SRCS = ecc_test.c
 
 PULP_CFLAGS = -O3
 
-ifdef fault_inject
+ifeq ($(fault_inject),1)
 	export FAULT_INJECTION=1
 	export FAULT_INJECTION_SCRIPT=$(CURDIR)/pulp_inject_fault.tcl
 endif
 
-ifdef multi_bit_upset
+ifeq ($(multi_bit_upset),1)
 	export MULTI_BIT_UPSET=1
 endif
 

--- a/carfield/ecc_test/pulp_inject_fault.tcl
+++ b/carfield/ecc_test/pulp_inject_fault.tcl
@@ -28,7 +28,7 @@ set max_num_fault_inject 0
 set signal_fault_duration 20ns
 set register_fault_duration 0ns
 
-set allow_multi_bit_upset [info exists ::env(MULTI_BIT_UPSET)]
+set allow_multi_bit_upset $::env(MULTI_BIT_UPSET)
 set use_bitwidth_as_weight 0
 set check_core_output_modification 0
 set check_core_next_state_modification 0


### PR DESCRIPTION
Fix the way fault injection can be enabled via cli. Make sure that the cli argument is defined AND equal to 1.