### PR TITLE
Add fault injection tests for Astral cluster HWPEs

### DIFF
--- a/hwpe/neureka/Makefile
+++ b/hwpe/neureka/Makefile
@@ -31,4 +31,15 @@ PULP_CFLAGS += $(INC_FLAGS) -O3
 
 PULP_APP = test
 
+ifeq ($(fault_inject),1)
+  export FAULT_INJECTION=1
+  export FAULT_INJECTION_SCRIPT=$(CURDIR)/pulp_inject_fault.tcl
+endif
+
+ifeq ($(multi_bit_upset),1)
+  export MULTI_BIT_UPSET=1
+else
+  export MULTI_BIT_UPSET=0
+endif
+
 include $(PULP_SDK_HOME)/install/rules/pulp_rt.mk

--- a/hwpe/neureka/inc/ecc_check.h
+++ b/hwpe/neureka/inc/ecc_check.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 ETH Zurich and University of Bologna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __ECC_CHECK_H__
+#define __ECC_CHECK_H__
+
+#include <stdint.h>
+
+#define ECC_REGS (4)
+extern uint32_t ecc_errs[ECC_REGS];
+
+#endif // __ECC_CHECK_H__

--- a/hwpe/neureka/pulp_inject_fault.tcl
+++ b/hwpe/neureka/pulp_inject_fault.tcl
@@ -1,0 +1,53 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Michael Rogenmoser (michaero@iis.ee.ethz.ch)
+
+transcript quietly
+if {! [info exists ::env(VSIM_PATH)]} {error "Define VSIM_PATH"}
+set utils_base_path  [file join $::env(VSIM_PATH) scripts fault_injection_utils]
+set script_base_path [file join $::env(VSIM_PATH) fault_injection_sim scripts]
+
+set verbosity            2
+set log_injections       1
+# Easy way to generate a variable seed
+# set seed                 [clock seconds]
+# Default value
+set seed                 12345
+set print_statistics     1
+
+set inject_start_time  80000000000ps
+set inject_stop_time  150000000000ps
+set injection_clock "pulp_cluster_tb/cluster_i/clk_i"
+set injection_clock_trigger 0
+set fault_period 100
+set rand_initial_injection_phase 1
+# max_num set to 0 means until stop_time
+set max_num_fault_inject 0
+set signal_fault_duration 20ns
+set register_fault_duration 0ns
+
+set allow_multi_bit_upset $::env(MULTI_BIT_UPSET)
+set use_bitwidth_as_weight 0
+set check_core_output_modification 0
+set check_core_next_state_modification 0
+set reg_to_sig_ratio 1
+
+source [file join $utils_base_path pulp_extract_nets.tcl]
+
+set inject_signals_netlist []
+set inject_register_netlist []
+set output_netlist []
+set next_state_netlist []
+set assertion_disable_list []
+
+# for {set idx 0} {$idx < 12} {incr idx} {
+#     set inject_signals_netlist [list {*}$inject_signals_netlist {*}[get_all_core_nets $idx]]
+#     set output_netlist [list {*}$output_netlist {*}[get_core_output_nets $idx]]
+# }
+
+set inject_register_netlist [list {*}$inject_register_netlist {*}[get_memory_slice {0 16} {0 50}]]
+
+source [file join $script_base_path inject_fault.tcl]
+

--- a/hwpe/neureka/src/nnx_layer.c
+++ b/hwpe/neureka/src/nnx_layer.c
@@ -19,6 +19,7 @@
  */
 
 #include "nnx_layer.h"
+#include "ecc_check.h"
 #include <pmsis.h>
 
 #include "neureka.h"
@@ -57,6 +58,7 @@ typedef neureka_task_flag_e nnx_task_flag_e;
 #define nnx_dispatch_wait neureka_nnx_dispatch_wait
 #define nnx_dispatch neureka_nnx_dispatch
 #define nnx_resolve_wait neureka_nnx_resolve_wait
+#define nnx_read_ecc_regs neureka_nnx_read_ecc_regs
 #define nnx_term neureka_nnx_term
 
 // Generated headers
@@ -159,6 +161,8 @@ static void task_execute(nnx_task_t *task) {
 #endif
 
   nnx_resolve_wait(dev, task);
+
+  nnx_read_ecc_regs(dev, (uint32_t)ecc_errs);
 
   nnx_term(dev);
 

--- a/hwpe/redmule/Makefile
+++ b/hwpe/redmule/Makefile
@@ -6,4 +6,15 @@ ifeq ($(use_dma),1)
  PULP_CFLAGS += -DUSE_DMA
 endif
 
+ifeq ($(fault_inject),1)
+  export FAULT_INJECTION=1
+  export FAULT_INJECTION_SCRIPT=$(CURDIR)/pulp_inject_fault.tcl
+endif
+
+ifeq ($(multi_bit_upset),1)
+  export MULTI_BIT_UPSET=1
+else
+  export MULTI_BIT_UPSET=0
+endif
+
 include $(PULP_SDK_HOME)/install/rules/pulp_rt.mk

--- a/hwpe/redmule/archi_redmule.h
+++ b/hwpe/redmule/archi_redmule.h
@@ -119,6 +119,12 @@
 #define REDMULE_REG_X_TOT_LEN_PTR      0x44
 #define REDMULE_REG_OP_SELECTION       0x48
 
+#define REDMULE_ECC_REG_OFFS           0x90
+#define DATA_CORR_ERR                  0x00
+#define DATA_UNCORR_ERR                0x04
+#define METADATA_CORR_ERR              0x08
+#define METADATA_UNCORR_ERR            0x0c
+
 // OPs definition
 #define MATMUL 0x0
 #define GEMM   0x1

--- a/hwpe/redmule/hal_redmule.h
+++ b/hwpe/redmule/hal_redmule.h
@@ -99,6 +99,22 @@ static inline void redmule_evt_wait() {
   } while((*(int volatile *)(ARCHI_CLUST_HWPE_BASE + REDMULE_STATUS)) != 0);
 }
 
+static inline unsigned int redmule_get_data_correctable_count () {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + DATA_CORR_ERR);
+}
+
+static inline unsigned int redmule_get_data_uncorrectable_count () {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + DATA_UNCORR_ERR);
+}
+
+static inline unsigned int redmule_get_meta_correctable_count () {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + METADATA_CORR_ERR);
+}
+
+static inline unsigned int redmule_get_meta_uncorrectable_count () {
+  return HWPE_READ(REDMULE_ECC_REG_OFFS + METADATA_UNCORR_ERR);
+}
+
 /* DMA APIs */
 static inline int mchan_alloc(){
   return *(volatile int*) DMA_COMMAND_QUEUE;

--- a/hwpe/redmule/pulp_inject_fault.tcl
+++ b/hwpe/redmule/pulp_inject_fault.tcl
@@ -1,0 +1,53 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Michael Rogenmoser (michaero@iis.ee.ethz.ch)
+
+transcript quietly
+if {! [info exists ::env(VSIM_PATH)]} {error "Define VSIM_PATH"}
+set utils_base_path  [file join $::env(VSIM_PATH) scripts fault_injection_utils]
+set script_base_path [file join $::env(VSIM_PATH) fault_injection_sim scripts]
+
+set verbosity            2
+set log_injections       1
+# Easy way to generate a variable seed
+# set seed                 [clock seconds]
+# Default value
+set seed                 12345
+set print_statistics     1
+
+set inject_start_time 550000000000ps
+set inject_stop_time 750000000000ps
+set injection_clock "pulp_cluster_tb/cluster_i/clk_i"
+set injection_clock_trigger 0
+set fault_period 150
+set rand_initial_injection_phase 0
+# max_num set to 0 means until stop_time
+set max_num_fault_inject 0
+set signal_fault_duration 20ns
+set register_fault_duration 0ns
+
+set allow_multi_bit_upset $::env(MULTI_BIT_UPSET)
+set use_bitwidth_as_weight 0
+set check_core_output_modification 0
+set check_core_next_state_modification 0
+set reg_to_sig_ratio 1
+
+source [file join $utils_base_path pulp_extract_nets.tcl]
+
+set inject_signals_netlist []
+set inject_register_netlist []
+set output_netlist []
+set next_state_netlist []
+set assertion_disable_list []
+
+# for {set idx 0} {$idx < 12} {incr idx} {
+#     set inject_signals_netlist [list {*}$inject_signals_netlist {*}[get_all_core_nets $idx]]
+#     set output_netlist [list {*}$output_netlist {*}[get_core_output_nets $idx]]
+# }
+
+set inject_register_netlist [list {*}$inject_register_netlist {*}[get_memory_slice {0 16} {256 336}]]
+
+source [file join $script_base_path inject_fault.tcl]
+


### PR DESCRIPTION
This PR introduces the option of running HWPEs regression tests with fault injection in memory to test the ECC-extended HCI of Astral cluster.